### PR TITLE
Fix for missing PanSTARRS-1 images

### DIFF
--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -1,0 +1,15 @@
+Acknowledgements
+-------------
+
+Digitized Sky Surveys
+-------------
+Images are retrieved from http://alasky.u-strasbg.fr/DSS/DSSColor/
+
+The Digitized Sky Surveys were produced at the Space Telescope Science Institute under U.S. Government grant NAG W-2166. The images of these surveys are based on photographic data obtained using the Oschin Schmidt Telescope on Palomar Mountain and the UK Schmidt Telescope. The plates were processed into the present compressed digital form with the permission of these institutions. The National Geographic Society - Palomar Observatory Sky Atlas (POSS-I) was made by the California Institute of Technology with grants from the National Geographic Society. The Second Palomar Observatory Sky Survey (POSS-II) was made by the California Institute of Technology with funds from the National Science Foundation, the National Geographic Society, the Sloan Foundation, the Samuel Oschin Foundation, and the Eastman Kodak Corporation. The Oschin Schmidt Telescope is operated by the California Institute of Technology and Palomar Observatory. The UK Schmidt Telescope was operated by the Royal Observatory Edinburgh, with funding from the UK Science and Engineering Research Council (later the UK Particle Physics and Astronomy Research Council), until 1988 June, and thereafter by the Anglo-Australian Observatory. The blue plates of the southern Sky Atlas and its Equatorial Extension (together known as the SERC-J), as well as the Equatorial Red (ER), and the Second Epoch [red] Survey (SES) were all taken with the UK Schmidt. Supplemental funding for sky-survey work at the STScI is provided by the European Southern Observatory.
+
+
+PanSTARRS DR1 color
+-------------
+Images are retrieved from http://alasky.u-strasbg.fr/Pan-STARRS/DR1/color-z-zg-g
+
+The Pan-STARRS1 Surveys (PS1) and the PS1 public science archive have been made possible through contributions by the Institute for Astronomy, the University of Hawaii, the Pan-STARRS Project Office, the Max-Planck Society and its participating institutes, the Max Planck Institute for Astronomy, Heidelberg and the Max Planck Institute for Extraterrestrial Physics, Garching, The Johns Hopkins University, Durham University, the University of Edinburgh, the Queen's University Belfast, the Harvard-Smithsonian Center for Astrophysics, the Las Cumbres Observatory Global Telescope Network Incorporated, the National Central University of Taiwan, the Space Telescope Science Institute, the National Aeronautics and Space Administration under Grant No. NNX08AR22G issued through the Planetary Science Division of the NASA Science Mission Directorate, the National Science Foundation Grant No. AST-1238877, the University of Maryland, Eotvos Lorand University (ELTE), the Los Alamos National Laboratory, and the Gordon and Betty Moore Foundation.

--- a/get_images.py
+++ b/get_images.py
@@ -14,6 +14,12 @@ from PIL import Image, ImageDraw, ImageFont
 
 def within_footprint(survey_url, the_star, logger):
     """Checks if the star is within the footprint of a given survey."""
+
+    # PanSTARRS-1 gets a little hairy below -29.5 degrees but still returns images.
+    # There are also places of no images (see Gaia eDR3 5463018973958284928)
+    # but the MOC thinks there are images, but actually you get gibberish.
+    if ('Pan-STARRS' in survey_url) and the_star['dec'] < 29.5:
+        return False
     try:
         moc_url = f"{survey_url}/Moc.fits"
         survey_moc = MOC.from_fits(moc_url)

--- a/get_images.py
+++ b/get_images.py
@@ -18,7 +18,7 @@ def within_footprint(survey_url, the_star, logger):
     # PanSTARRS-1 gets a little hairy below -29.5 degrees but still returns images.
     # There are also places of no images (see Gaia eDR3 5463018973958284928)
     # but the MOC thinks there are images, but actually you get gibberish.
-    if ('Pan-STARRS' in survey_url) and the_star['dec'] < 29.5:
+    if ("Pan-STARRS" in survey_url) and the_star['dec'] < 29.5:
         return False
     try:
         moc_url = f"{survey_url}/Moc.fits"
@@ -34,7 +34,9 @@ def within_footprint(survey_url, the_star, logger):
 def download_image(survey_url, the_star, logger, base_image):
     """Downloads the HiPS image.
 
-    This research made use of hips2fits, (https://alasky.u-strasbg.fr/hips-image-services/hips2fits) a service provided by CDS."""
+    This research made use of hips2fits,
+    (https://alasky.u-strasbg.fr/hips-image-services/hips2fits)
+    a service provided by CDS."""
     width = 1000
     height = 1000
     fov = 0.25
@@ -49,7 +51,6 @@ def download_image(survey_url, the_star, logger, base_image):
             shutil.copyfileobj(response.raw, out_file)
             logger.info("Saved the image to %s", base_image)
         del response
-        return 0
     else:
         logger.error("BAD HTTP response: %s", response.status_code)
         logger.error("Did not get the sky image. Quitting.")
@@ -67,7 +68,7 @@ def get_hips_image(the_star, secrets_dict):
 
     gaia_dr3_id = the_star['dr3_source_id']
 
-    ohips = [['Pan-STARRS', 'http://alasky.u-strasbg.fr/Pan-STARRS/DR1/color-z-zg-g'],
+    ohips = [['PanSTARRS-1', 'http://alasky.u-strasbg.fr/Pan-STARRS/DR1/color-z-zg-g'],
              ['DECaLS',  'http://alasky.u-strasbg.fr/DECaLS/DR5/color'],
              ['DSS2',  "http://alasky.u-strasbg.fr/DSS/DSSColor"]
              ]
@@ -77,9 +78,10 @@ def get_hips_image(the_star, secrets_dict):
     for survey, survey_url in ohips:
         logger.info("Trying %s", survey)
         if within_footprint(survey_url, the_star, logger):
+
             logger.info("Target is within footprint of %s", survey)
-            res = download_image(survey_url, the_star, logger, base_image)
-            if res == 0:
+            download_image(survey_url, the_star, logger, base_image)
+            if base_image.is_file():
                 break
         else:
             logger.info("Target is *not* within footprint of %s", survey)
@@ -94,7 +96,6 @@ def get_hips_image(the_star, secrets_dict):
         logger.error(e)
         logger.error("Could not load the sky image. Quitting.")
         sys.exit("Could not load the sky image. Quitting.")
-        return 1
     logger.info("Adding the overlay")
     draw = ImageDraw.Draw(img_sky, "RGBA")
     draw.line([((500 - 80), 500),

--- a/robot_galah.py
+++ b/robot_galah.py
@@ -115,8 +115,8 @@ def main():
                     (the_star['snr_c3_iraf'] > 30)):
                 USEFUL_STAR = True
                 logger.info("Found a useful star: %s", the_star['sobject_id'])
-
     logger.debug("Extracting the useful information about the star")
+    logger.debug("RA = %f, Dec = %f", the_star['ra'], the_star['dec'])
     gaia_dr3_id = the_star['dr3_source_id']
     YYMMDD = str(the_star['sobject_id'])[:6]
     d = datetime.strptime(YYMMDD, "%y%m%d").date()
@@ -138,6 +138,7 @@ def main():
     hips_survey = get_hips_image(the_star, secrets_dict)
     plot_spectra(the_star)
     tweet(tweet_text, hips_survey, gaia_dr3_id, secrets_dict, DRY_RUN)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
In some instances there were stars that were getting a PanSTARR-1 image, but it was actually blank. This checks if the star is too far south for there to actually be an image. It also avoids images like this one.

<img width="818" alt="Screen Shot 2021-05-02 at 10 53 52 am" src="https://user-images.githubusercontent.com/1392649/116798605-b055e380-ab34-11eb-9675-7e66b67fb8b8.png">
